### PR TITLE
HOTFIX: Only supports courseID format [A-Z][A-Z][0-9][0-9][0-9][0-9]

### DIFF
--- a/js/lookup.js
+++ b/js/lookup.js
@@ -177,8 +177,7 @@ function getEquivalents(dataString) {
     endIndex = startIndex + dataString.slice(startIndex, dataString.length).search(/[, .]/g);
 
     var slicedData = dataString.slice(startIndex, endIndex);
-
-    equivalents.push(slicedData.split("/"));
+    equivalents = slicedData.match(/[A-Z][A-Z][0-9][0-9][0-9][0-9]/g);
     dataString = dataString.replace(slicedData, "");
 
   }


### PR DESCRIPTION
Equivalent courses of other formats (XXX0000, XX0000X, ... etc) is not supported